### PR TITLE
Fix "ghost" weather display in expanded status bar

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarHeaderView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarHeaderView.java
@@ -856,7 +856,9 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
             final boolean showingDetail = detail != null;
             transition(mClock, !showingDetail);
             transition(mDateGroup, !showingDetail);
-            transition(mWeatherContainer, !showingDetail);
+            if (mShowWeather) {
+                transition(mWeatherContainer, !showingDetail);
+            }
             if (mAlarmShowing) {
                 transition(mAlarmStatus, !showingDetail);
             }


### PR DESCRIPTION
- How to repoduce -
  1 - Disable weather in status bar option
  2 - Expanded status bar
  3 - Click, for example, in modile data to open Cellular data sub settings
  4 - Toggel cellular data on/off or click in "DONE"
  5 - Now check the status bar and you'll see weather info!

NOTE: If you swipe up and down again all get back to normal because updateVisibilities() is called in StatusBarHeaderView.java

Simple solve it (i don't know if this is the better way) by updating weather settings visibility inside handleShowingDetail(final QSTile.DetailAdapter detail)

Correct fix "ghost" weather display in expanded status bar
- Thanks to the hint of @Altaf-Mahdi. All credits gos to him. check our comments here:
  https://github.com/crdroidandroid/android_frameworks_base/commit/607175f0fe6469600e01339f2b93e4b1edabc275

Change-Id: If36339ecad00296e81e42dc99748f30f5f6447e8
