### PR TITLE
Themes: Handle case when keyguard is showing during theme change

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -3724,6 +3724,17 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         });
         // restart the keyguard so it picks up the newly created ScrimController
         startKeyguard();
+
+        // if the keyguard was showing while this change occurred we'll need to do some extra work
+        if (mState == StatusBarState.KEYGUARD) {
+            // this will make sure the keyguard is showing
+            showKeyguard();
+            // The following views need to be invisible if the keyguard is showing
+            // These views were hidden but re-inflating the status bar changed them back to visible
+            mClockView.setVisibility(View.INVISIBLE);
+            mNotificationIconArea.setVisibility(View.INVISIBLE);
+            mSystemIconArea.setVisibility(View.INVISIBLE);
+        }
     }
 
     private void removeAllViews(ViewGroup parent) {


### PR DESCRIPTION
After we recreate the status bar we need to check if the keyguard
was showing and if so make sure it is showing after the theme
change.  We also need to make sure the phone status bar is not
visible if the keyguard was showing, otherwise you see two status
bars.

Change-Id: Iba09e3e5c8cf52d49f292423a50034a3cf84d9c1
